### PR TITLE
Fix CLI main exit code

### DIFF
--- a/src/llm_forge/cli/main.py
+++ b/src/llm_forge/cli/main.py
@@ -162,7 +162,7 @@ def main() -> ExitCode:
     that weren't caught by individual commands.
 
     Returns:
-        int: 0 for success or handled errors, representing a clean exit
+        int: 0 for success. Non-zero indicates failure.
 
     Examples:
         $ python -m llm_forge.cli.main
@@ -172,7 +172,7 @@ def main() -> ExitCode:
         return 0
     except Exception as e:
         logger.error(f"Unexpected error: {e}")
-        return 0
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- raise failure exit status when CLI `main()` sees an exception
- document that a non-zero exit code signals failure

## Testing
- `pytest -q`
- `ruff check src/llm_forge/cli/main.py`
- `black --check src/llm_forge/cli/main.py`
- `isort --check src/llm_forge/cli/main.py`

------
https://chatgpt.com/codex/tasks/task_b_684c03d77294832385758fa79a384a3c